### PR TITLE
fix: re-enable CSP at page level

### DIFF
--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     viewportWidth: 1366,
     viewportHeight: 768,
     watchForFileChanges: false,
+    experimentalCspAllowList: true, // Needed so Cypress do not strip the CSP headers and directives
     e2e: {
         // We've imported your old cypress plugins here.
         // You may want to clean this up later by importing these.

--- a/tests/cypress/e2e/contentSecurityPolicyHeaders.cy.ts
+++ b/tests/cypress/e2e/contentSecurityPolicyHeaders.cy.ts
@@ -22,6 +22,14 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
         setNodeProperty(path, 'cspReportOnly', reportOnly.toString(), 'en');
     }
 
+    function configureCSPPolicyForPage(page: string, policy: string, reportOnly = false) {
+        const path = `/sites/${SITE_KEY}/${page}`;
+        addMixins(path, ['jmix:siteContentSecurityPolicy']);
+        setNodeProperty(path, 'policy', policy, 'en');
+        setNodeProperty(path, 'cspReportOnly', reportOnly.toString(), 'en');
+        publishAndWaitJobEnding(path, ['en']);
+    }
+
     beforeEach('create test data', () => {
         createSite(SITE_KEY, {
             locale: 'en',
@@ -54,7 +62,7 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
         });
     });
 
-    it('GIVEN CSP configured at the site level with a policy WHEN loading a page THEN the response headers are correctly set for all pages', () => {
+    it('GIVEN CSP configured at the site level with a policy WHEN loading pages THEN the response headers are correctly set for all pages', () => {
         enableCSPModule();
         const policy = 'script-src \'self\' js.example.com';
         configureCSPPolicyGlobally(policy);
@@ -68,7 +76,7 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
         });
     });
 
-    it('GIVEN CSP configured at the site level with a policy and report only WHEN loading a page THEN the response headers are correctly set for all pages', () => {
+    it('GIVEN CSP configured at the site level with a policy and report only WHEN loading pages THEN the response headers are correctly set for all pages', () => {
         enableCSPModule();
         const policy = 'default-src \'self\'';
         configureCSPPolicyGlobally(policy, true);
@@ -80,5 +88,51 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
                 expect(response.headers['reporting-endpoints']).to.equal(`csp-endpoint="/sites/${SITE_KEY}/${page}.contentSecurityPolicyReportOnly.do"`);
             });
         });
+    });
+
+    it('GIVEN CSP configured at the site level and for a page WHEN loading pages THEN the response headers for that page contain the additional directives', () => {
+        enableCSPModule();
+        const sitePolicy = 'script-src \'self\' js.example.com';
+        configureCSPPolicyGlobally(sitePolicy);
+        const pagePolicy = 'img-src \'none\'; style-src \'none\'';
+        configureCSPPolicyForPage('home', pagePolicy);
+        cy.intercept(`/sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do`, {}).as('cspAttacks');
+
+        cy.request(`/sites/${SITE_KEY}/home.html`).then(response => {
+            // Page with both site and page policies
+            expect(response.headers['content-security-policy'], 'the header should contain both the site and the page policies').to.equal(`${sitePolicy};${pagePolicy}; report-uri /sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do; report-to csp-endpoint`);
+            expect(response.headers['content-security-policy-report-only']).to.be.undefined;
+            expect(response.headers['reporting-endpoints']).to.equal(`csp-endpoint="/sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do"`);
+        });
+        cy.request(`/sites/${SITE_KEY}/simple.html`).then(response => {
+            // Page with only site policy
+            expect(response.headers['content-security-policy'], 'the header should only contain the site policy').to.equal(`${sitePolicy}; report-uri /sites/${SITE_KEY}/simple.contentSecurityPolicyReportOnly.do; report-to csp-endpoint`);
+            expect(response.headers['content-security-policy-report-only']).to.be.undefined;
+            expect(response.headers['reporting-endpoints']).to.equal(`csp-endpoint="/sites/${SITE_KEY}/simple.contentSecurityPolicyReportOnly.do"`);
+        });
+        cy.wait('@cspAttacks').its('request.body').should('include', 'blocked');
+    });
+
+    it('GIVEN CSP configured to restrict img src WHEN loading a page THEN only the legit resources should be loaded by the browser', () => {
+        enableCSPModule();
+        const sitePolicy = 'img-src example.com';
+        configureCSPPolicyGlobally(sitePolicy);
+        const legitResource = 'https://example.com/legit.jpg';
+        const forbiddenResource = 'https://hacker.com/forbidden.jpg';
+        cy.intercept('**/*.jpg', {statusCode: 200}).as('images');
+
+        cy.visit(`/sites/${SITE_KEY}/home.html`);
+        cy.get('#htmlInput').type(`Injected images:<img src="${forbiddenResource}"/><img src="${legitResource}"/>`);
+        cy.get('#sendButton').click();
+        cy.contains('#outputDiv', 'Injected images');
+
+        cy.wait('@images').its('response.statusCode').should('eq', 200);
+        cy.get('@images.all').then(interceptions => {
+            console.log('interceptions', interceptions);
+            const requestedUrls = interceptions.map(interception => interception.request.url);
+            expect(requestedUrls).to.include(legitResource);
+            expect(requestedUrls).to.not.include(forbiddenResource);
+        });
+        // NB: it's not possible to test that the browser actually calls the CSP endpoint as the endpoint must use https (which is not the case in our CI setup)
     });
 });

--- a/tests/cypress/e2e/contentSecurityPolicyHeaders.cy.ts
+++ b/tests/cypress/e2e/contentSecurityPolicyHeaders.cy.ts
@@ -128,7 +128,6 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
 
         cy.wait('@images').its('response.statusCode').should('eq', 200);
         cy.get('@images.all').then(interceptions => {
-            console.log('interceptions', interceptions);
             const requestedUrls = interceptions.map(interception => interception.request.url);
             expect(requestedUrls).to.include(legitResource);
             expect(requestedUrls).to.not.include(forbiddenResource);

--- a/tests/cypress/e2e/contentSecurityPolicyHeaders.cy.ts
+++ b/tests/cypress/e2e/contentSecurityPolicyHeaders.cy.ts
@@ -96,7 +96,6 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
         configureCSPPolicyGlobally(sitePolicy);
         const pagePolicy = 'img-src \'none\'; style-src \'none\'';
         configureCSPPolicyForPage('home', pagePolicy);
-        cy.intercept(`/sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do`, {}).as('cspAttacks');
 
         cy.request(`/sites/${SITE_KEY}/home.html`).then(response => {
             // Page with both site and page policies
@@ -110,7 +109,6 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
             expect(response.headers['content-security-policy-report-only']).to.be.undefined;
             expect(response.headers['reporting-endpoints']).to.equal(`csp-endpoint="/sites/${SITE_KEY}/simple.contentSecurityPolicyReportOnly.do"`);
         });
-        cy.wait('@cspAttacks').its('request.body').should('include', 'blocked');
     });
 
     it('GIVEN CSP configured to restrict img src WHEN loading a page THEN only the legit resources should be loaded by the browser', () => {

--- a/tests/jahia-module/src/main/resources/jnt_template/html/template.sampleView.jsp
+++ b/tests/jahia-module/src/main/resources/jnt_template/html/template.sampleView.jsp
@@ -18,7 +18,16 @@
 <div class="body">
     This is a sample view
 </div>
+<textarea id="htmlInput" rows="10" cols="50" placeholder="Enter your HTML code here"></textarea>
+<br>
+<button id="sendButton">Send</button>
+<div id="outputDiv"></div>
 
+<script>
+    document.getElementById('sendButton').addEventListener('click', function() {
+        document.getElementById('outputDiv').innerHTML = document.getElementById('htmlInput').value;
+    });
+</script>
 <c:if test="${renderContext.editMode}">
     <template:addResources type="css" resources="edit.css" />
 </c:if>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Re-enable the ability to setup a Content Security Policy at a page level, that was removed by mistake in [this commit](https://github.com/Jahia/content-security-policy/commit/6b27995d3b00800416f4f69a4356b100a78297f6).

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Also, include a test to validate the CSP is respected by the browser.
