### PR TITLE
feat: page-level policies replace site-level policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,8 @@ content-security-policy
 =====================
 
 The purpose of this module is to allow the definition of a Content Security Policy for a website inside [Digital Experience Manager](https://www.jahia.com).
-For more information about the **Content Security Policy**, please refer to this URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Installation
-
-- In DX, go to "Administration --> Server settings --> System components --> Modules"
-- Upload the JAR `content-security-policy-X.X.X.jar`
-- Check that the module is started
-
-# Use
-
-## Administration
-
-- Go to "Administration -> Server settings -> Web Projects"
-- Edit the site with which you want to use this module and add it to the list of the deployed modules
-
-## Edit mode
-
- * CSP at the site level:
-   * Go to the "Edit mode", right click on the root of the site and edit it
-   * Go to the tab "Options" and activate the item "Add Content Security Policy at the site level"
-   * Add in the text area the policy on one line
- * CSP at the page level:
-   * Go to the "Edit mode", right click on the page and edit it
-   * Go to the tab "Options" and activate the item "Add Content Security Policy at the page level"
-   * Add in the text area the policy on one line
-   * Publish the page
+For more details about installation and usage, please refer to the [Jahia store](https://store.jahia.com/contents/modules-repository/org/jahia/modules/content-security-policy.html).
 
 ## Open-Source
 

--- a/src/main/java/org/jahia/modules/csp/AddContentSecurityPolicy.java
+++ b/src/main/java/org/jahia/modules/csp/AddContentSecurityPolicy.java
@@ -23,15 +23,6 @@
  */
 package org.jahia.modules.csp;
 
-import java.nio.ByteBuffer;
-import java.util.Base64;
-import java.util.Base64.Encoder;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang.StringUtils;
 import org.jahia.modules.csp.actions.ReportOnlyAction;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -41,6 +32,12 @@ import org.jahia.services.render.Resource;
 import org.jahia.services.render.filter.AbstractFilter;
 import org.jahia.services.render.filter.RenderChain;
 import org.jahia.settings.SettingsBean;
+
+import javax.servlet.http.HttpServletResponse;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Base64.Encoder;
+import java.util.UUID;
 
 public final class AddContentSecurityPolicy extends AbstractFilter {
 

--- a/src/main/java/org/jahia/modules/csp/AddContentSecurityPolicy.java
+++ b/src/main/java/org/jahia/modules/csp/AddContentSecurityPolicy.java
@@ -65,12 +65,10 @@ public final class AddContentSecurityPolicy extends AbstractFilter {
         final HttpServletResponse response = renderContext.getResponse();
 
         final JCRSiteNode site = renderContext.getSite();
-        final String siteContentSecurityPolicy = site.hasProperty(CSP_PROPERTY) ? site.getProperty(CSP_PROPERTY).getString() : null;
         final JCRNodeWrapper page = renderContext.getMainResource().getNode();
-        final String pageContentSecurityPolicy = page.hasProperty(CSP_PROPERTY) ? page.getProperty(CSP_PROPERTY).getString() : null;
-        final String policyDirectives = Stream.of(siteContentSecurityPolicy, pageContentSecurityPolicy)
-                .filter(Objects::nonNull)
-                .collect(Collectors.joining(CSP_SEPARATOR));
+
+        // use CSP at page-level first, otherwise use the one defined at site-level
+        final String policyDirectives = page.hasProperty(CSP_PROPERTY) ? page.getProperty(CSP_PROPERTY).getString() : site.hasProperty(CSP_PROPERTY) ? site.getProperty(CSP_PROPERTY).getString() : null;
 
         final String nonce = getNonceValue();
 

--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -7,3 +7,9 @@
  - policy (string,textarea) nofulltext indexed=no
  - cspReportOnly (boolean) = false indexed=no
 
+
+[jmix:pageContentSecurityPolicy] mixin
+ extends = jnt:page
+ itemtype = options
+ - policy (string,textarea) nofulltext indexed=no
+

--- a/src/main/resources/resources/content-security-policy.properties
+++ b/src/main/resources/resources/content-security-policy.properties
@@ -1,3 +1,3 @@
-jmix_pageContentSecurityPolicy=Add Content Security Policy at the page level
+jmix_pageContentSecurityPolicy=Replace Content-Security-Policy at the page level
 jmix_siteContentSecurityPolicy.cspReportOnly=Only report CSP violations
-jmix_siteContentSecurityPolicy=Add Content Security Policy at the site level
+jmix_siteContentSecurityPolicy=Add Content-Security-Policy at the site level

--- a/src/main/resources/resources/content-security-policy.properties
+++ b/src/main/resources/resources/content-security-policy.properties
@@ -1,2 +1,3 @@
+jmix_pageContentSecurityPolicy=Add Content Security Policy at the page level
 jmix_siteContentSecurityPolicy.cspReportOnly=Only report CSP violations
 jmix_siteContentSecurityPolicy=Add Content Security Policy at the site level

--- a/tests/cypress/e2e/contentSecurityPolicy.cy.ts
+++ b/tests/cypress/e2e/contentSecurityPolicy.cy.ts
@@ -24,7 +24,7 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
 
     function configureCSPPolicyForPage(page: string, policy: string, reportOnly = false) {
         const path = `/sites/${SITE_KEY}/${page}`;
-        addMixins(path, ['jmix:siteContentSecurityPolicy']);
+        addMixins(path, ['jmix:pageContentSecurityPolicy']);
         setNodeProperty(path, 'policy', policy, 'en');
         setNodeProperty(path, 'cspReportOnly', reportOnly.toString(), 'en');
         publishAndWaitJobEnding(path, ['en']);

--- a/tests/cypress/e2e/contentSecurityPolicy.cy.ts
+++ b/tests/cypress/e2e/contentSecurityPolicy.cy.ts
@@ -90,7 +90,7 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
         });
     });
 
-    it('GIVEN CSP configured at the site level and for a page WHEN loading pages THEN the response headers for that page contain the additional directives', () => {
+    it('GIVEN CSP configured at the site level and at the page level WHEN loading pages THEN the page-level policies replace the site-level policies', () => {
         enableCSPModule();
         const sitePolicy = 'script-src \'self\' js.example.com';
         configureCSPPolicyGlobally(sitePolicy);
@@ -98,8 +98,8 @@ describe('Test response headers of the Content Security Policy (CSP) filter', ()
         configureCSPPolicyForPage('home', pagePolicy);
 
         cy.request(`/sites/${SITE_KEY}/home.html`).then(response => {
-            // Page with both site and page policies
-            expect(response.headers['content-security-policy'], 'the header should contain both the site and the page policies').to.equal(`${sitePolicy};${pagePolicy}; report-uri /sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do; report-to csp-endpoint`);
+            // Page with page policies
+            expect(response.headers['content-security-policy'], 'the header should contain both the site and the page policies').to.equal(`${pagePolicy}; report-uri /sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do; report-to csp-endpoint`);
             expect(response.headers['content-security-policy-report-only']).to.be.undefined;
             expect(response.headers['reporting-endpoints']).to.equal(`csp-endpoint="/sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do"`);
         });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Allow CSP policies to be defined at a page-level, that take precedence over the CSP policies defined at the site-level.
Covers https://github.com/Jahia/content-security-policy/issues/29.

## Tests

The following are included in this PR
- [x] Integration Tests

