### PR TITLE
fix: bound the size of an accepted violation report

### DIFF
--- a/.chachalog/report-endpoint-bounds.md
+++ b/.chachalog/report-endpoint-bounds.md
@@ -1,0 +1,5 @@
+---
+content-security-policy: patch
+---
+
+The built-in violation report endpoint accepts reports up to 64 KB and refuses anything larger, and the report it writes to the log is a single line.

--- a/src/main/java/org/jahia/modules/csp/actions/ReportOnlyAction.java
+++ b/src/main/java/org/jahia/modules/csp/actions/ReportOnlyAction.java
@@ -70,7 +70,9 @@ public final class ReportOnlyAction extends Action {
                 if (length > MAX_REPORT_BYTES) {
                     return ActionResult.BAD_REQUEST;
                 }
-                LOGGER.warn("{}", asSingleLine(new String(buffer, 0, length, StandardCharsets.UTF_8)));
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn("{}", asSingleLine(new String(buffer, 0, length, StandardCharsets.UTF_8)));
+                }
                 return ActionResult.OK;
             }
         }

--- a/src/main/java/org/jahia/modules/csp/actions/ReportOnlyAction.java
+++ b/src/main/java/org/jahia/modules/csp/actions/ReportOnlyAction.java
@@ -23,8 +23,10 @@
  */
 package org.jahia.modules.csp.actions;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.io.IOUtils;
 import org.jahia.bin.Action;
@@ -46,6 +48,11 @@ public final class ReportOnlyAction extends Action {
     public static final String CSP_REPORT_ONLY = "cspReportOnly";
     public static final String CSP_REPORT_URL = "cspReportUrl";
 
+    /** The largest report this action accepts; a violation report is a small JSON document. */
+    private static final int MAX_REPORT_BYTES = 64 * 1024;
+
+    private static final Pattern CONTROL_CHARACTERS = Pattern.compile("\\p{Cntrl}");
+
     @Activate
     public void activate() {
         setName("contentSecurityPolicyReportOnly");
@@ -57,12 +64,21 @@ public final class ReportOnlyAction extends Action {
         if ("application/csp-report".equals(req.getContentType())) {
             final JCRSiteNode site = renderContext.getSite();
             if (site.hasProperty(CSP_REPORT_ONLY) && site.getProperty(CSP_REPORT_ONLY).getBoolean()) {
-                final String report = IOUtils.toString(req.getInputStream());
-                LOGGER.warn(report);
+                // read one byte past the limit, so a report at the limit is still told apart from one over it
+                final byte[] buffer = new byte[MAX_REPORT_BYTES + 1];
+                final int length = IOUtils.read(req.getInputStream(), buffer);
+                if (length > MAX_REPORT_BYTES) {
+                    return ActionResult.BAD_REQUEST;
+                }
+                LOGGER.warn("{}", asSingleLine(new String(buffer, 0, length, StandardCharsets.UTF_8)));
                 return ActionResult.OK;
             }
         }
         return ActionResult.BAD_REQUEST;
+    }
+
+    private static String asSingleLine(String report) {
+        return CONTROL_CHARACTERS.matcher(report).replaceAll(" ");
     }
 
 }

--- a/tests/cypress/e2e/cspReportEndpointLimits.cy.ts
+++ b/tests/cypress/e2e/cspReportEndpointLimits.cy.ts
@@ -7,7 +7,14 @@ import {addMixins, createSite, deleteSite, enableModule, publishAndWaitJobEnding
 describe('CSP violation report endpoint', () => {
     const SITE_KEY = 'csp-report-endpoint-test-site';
     const ENDPOINT = `/sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do`;
-    const REPORT = '{"csp-report":{"document-uri":"http://localhost/","violated-directive":"script-src"}}';
+    const MAX_REPORT_BYTES = 64 * 1024;
+
+    const report = (blockedUri: string) =>
+        JSON.stringify({'csp-report': {'document-uri': 'http://localhost/', 'violated-directive': 'script-src', 'blocked-uri': blockedUri}});
+
+    // A report of an exact size is a valid one padded to it — the padding is ASCII, so one padding
+    // character is one byte.
+    const reportOf = (bytes: number) => report('x'.repeat(bytes - report('').length));
 
     const post = (body: string) =>
         cy.request({
@@ -36,13 +43,17 @@ describe('CSP violation report endpoint', () => {
     });
 
     it('accepts a violation report', () => {
-        post(REPORT).its('status').should('equal', 200);
+        post(report('http://localhost/inline')).its('status').should('equal', 200);
     });
 
-    it('refuses a report past the accepted size', () => {
-        // Anchor: the same request under the size is accepted, so a refusal below is about the size
-        post(REPORT).its('status').should('equal', 200);
+    it('accepts a report at the accepted size and refuses one byte past it', () => {
+        const atLimit = reportOf(MAX_REPORT_BYTES);
+        // The assumption the pair rests on: this report is 64 KB on the wire, not 64 K characters
+        expect(new TextEncoder().encode(atLimit)).to.have.length(MAX_REPORT_BYTES);
 
-        post('A'.repeat(1024 * 1024)).its('status').should('not.equal', 200);
+        // Anchor: the same report, one byte shorter, is accepted — so the refusal is about the size
+        // alone. Both bodies are valid reports; only their length differs.
+        post(atLimit).its('status').should('equal', 200);
+        post(reportOf(MAX_REPORT_BYTES + 1)).its('status').should('equal', 400);
     });
 });

--- a/tests/cypress/e2e/cspReportEndpointLimits.cy.ts
+++ b/tests/cypress/e2e/cspReportEndpointLimits.cy.ts
@@ -1,0 +1,48 @@
+import {addMixins, createSite, deleteSite, enableModule, publishAndWaitJobEnding, setNodeProperty} from '@jahia/cypress';
+
+/**
+ * The report endpoint takes an unauthenticated body, so what it accepts is bounded: a violation
+ * report is a small JSON document, and anything past that size is refused rather than read.
+ */
+describe('CSP violation report endpoint', () => {
+    const SITE_KEY = 'csp-report-endpoint-test-site';
+    const ENDPOINT = `/sites/${SITE_KEY}/home.contentSecurityPolicyReportOnly.do`;
+    const REPORT = '{"csp-report":{"document-uri":"http://localhost/","violated-directive":"script-src"}}';
+
+    const post = (body: string) =>
+        cy.request({
+            method: 'POST',
+            url: ENDPOINT,
+            body,
+            headers: {'Content-Type': 'application/csp-report'},
+            failOnStatusCode: false
+        });
+
+    beforeEach('create a site with report-only enabled', () => {
+        createSite(SITE_KEY, {
+            locale: 'en',
+            serverName: 'localhost',
+            templateSet: 'content-security-policy-test-module'
+        });
+        enableModule('content-security-policy', SITE_KEY);
+        addMixins(`/sites/${SITE_KEY}`, ['jmix:siteContentSecurityPolicy']);
+        setNodeProperty(`/sites/${SITE_KEY}`, 'policy', 'script-src \'self\'', 'en');
+        setNodeProperty(`/sites/${SITE_KEY}`, 'cspReportOnly', 'true', 'en');
+        publishAndWaitJobEnding(`/sites/${SITE_KEY}`, ['en']);
+    });
+
+    afterEach('delete the site', () => {
+        deleteSite(SITE_KEY);
+    });
+
+    it('accepts a violation report', () => {
+        post(REPORT).its('status').should('equal', 200);
+    });
+
+    it('refuses a report past the accepted size', () => {
+        // Anchor: the same request under the size is accepted, so a refusal below is about the size
+        post(REPORT).its('status').should('equal', 200);
+
+        post('A'.repeat(1024 * 1024)).its('status').should('not.equal', 200);
+    });
+});

--- a/tests/cypress/e2e/cspReportEndpointLimits.cy.ts
+++ b/tests/cypress/e2e/cspReportEndpointLimits.cy.ts
@@ -1,8 +1,8 @@
 import {addMixins, createSite, deleteSite, enableModule, publishAndWaitJobEnding, setNodeProperty} from '@jahia/cypress';
 
 /**
- * The report endpoint takes an unauthenticated body, so what it accepts is bounded: a violation
- * report is a small JSON document, and anything past that size is refused rather than read.
+ * A violation report is a small JSON document, so what this endpoint accepts is bounded: anything
+ * past that size is refused rather than read.
  */
 describe('CSP violation report endpoint', () => {
     const SITE_KEY = 'csp-report-endpoint-test-site';


### PR DESCRIPTION
## Summary

A CSP violation report is a small JSON document, and `ReportOnlyAction` now treats it as one: it
accepts up to 64 KB, refuses anything larger, and the report it writes to the log is a single line.

## Change

- The body is read into a fixed buffer of `MAX_REPORT_BYTES + 1`. Reading one byte past the limit is
  what lets a report *at* the limit be told apart from one over it; over the limit the action returns
  `BAD_REQUEST` and keeps nothing.
- The body is decoded as UTF-8. A CSP report is JSON, so its encoding is the document's, not the
  platform's.
- Control characters become spaces before the report is logged, so one report is one log line.

64 KB is the same limit #69 uses, so the two agree on the number. This change is deliberately narrow
— it touches only what `ReportOnlyAction` reads and logs. #69 remains the fuller treatment of the
endpoint, and its author knows this is going up.

## Verification

Run through the module's own Cypress harness against a running instance
(`ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT`), on a site configured for report-only:

- a violation report is accepted — HTTP 200;
- a valid report of exactly 64 KB is accepted, and the same report one byte longer is refused with
  `BAD_REQUEST` — the two bodies differ by size alone;
- separately, on the same instance: a report carrying `\r\n` and `\t` lands as a single log line,
  control characters flattened (confirmed by reading the raw bytes of the log).

The spec ships here (`tests/cypress/e2e/cspReportEndpointLimits.cy.ts`). Its acceptance case anchors
the refusal case: it passes on both sides, so a refusal cannot come from a broken fixture. The pair
was checked to bite rather than merely pass — with the bound made inclusive, the 64 KB case fails.

`mvn package` passes.

